### PR TITLE
Fix incorrect plugin identifier error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { WiserPlatformPlugin } from './WiserPlatformPlugin';
 
 export = (homebridge: API) => {
   homebridge.registerPlatform(
-    'homebridge-drayton-wiser',
+    '@string-bean/homebridge-drayton-wiser',
     'drayton-wiser',
     WiserPlatformPlugin,
   );


### PR DESCRIPTION
The `name` in package.json and in `registerPlatform` must match, this
will stop the following error:

> Plugin '@string-bean/homebridge-drayton-wiser' tried to register with an incorrect plugin identifier: 'homebridge-drayton-wiser'. Please report this to the developer!